### PR TITLE
Fix deprecated ::set-output syntax for GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: Test Action
+
+on:
+  push:
+    branches: [ main, fix-deprecated-set-output ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version-label: [main, stable, oldstable]
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Test Koha Version Action
+      id: koha-version
+      uses: ./
+      with:
+        version-label: ${{ matrix.version-label }}
+    
+    - name: Verify outputs
+      run: |
+        echo "Testing version-label: ${{ matrix.version-label }}"
+        echo "current-branch-name: ${{ steps.koha-version.outputs.current-branch-name }}"
+        echo "branch-name: ${{ steps.koha-version.outputs.branch-name }}"
+        echo "version-major-minor: ${{ steps.koha-version.outputs.version-major-minor }}"
+        echo "version-major: ${{ steps.koha-version.outputs.version-major }}"
+        echo "version-minor: ${{ steps.koha-version.outputs.version-minor }}"
+        
+        # Verify current-branch-name is not empty
+        if [[ -z "${{ steps.koha-version.outputs.current-branch-name }}" ]]; then
+          echo "ERROR: current-branch-name is empty"
+          exit 1
+        fi
+        
+        # Verify branch name format
+        BRANCH_NAME="${{ steps.koha-version.outputs.current-branch-name }}"
+        if [[ "${{ matrix.version-label }}" == "main" ]]; then
+          # For main, expect exactly "main"
+          if [[ "$BRANCH_NAME" != "main" ]]; then
+            echo "ERROR: Expected 'main' for main label, got '$BRANCH_NAME'"
+            exit 1
+          fi
+          echo "✅ Main branch name correct: $BRANCH_NAME"
+        else
+          # For stable/oldstable, expect format like "25.05.x" or "24.11.x"
+          if [[ ! "$BRANCH_NAME" =~ ^[0-9]{2}\.[0-9]{2}\.x$ ]]; then
+            echo "ERROR: Expected format 'XX.YY.x' for ${{ matrix.version-label }}, got '$BRANCH_NAME'"
+            exit 1
+          fi
+          
+          # Verify version outputs are populated for versioned branches
+          if [[ -z "${{ steps.koha-version.outputs.version-major-minor }}" ]]; then
+            echo "ERROR: version-major-minor is empty for ${{ matrix.version-label }}"
+            exit 1
+          fi
+          
+          if [[ -z "${{ steps.koha-version.outputs.version-major }}" ]]; then
+            echo "ERROR: version-major is empty for ${{ matrix.version-label }}"
+            exit 1
+          fi
+          
+          if [[ -z "${{ steps.koha-version.outputs.version-minor }}" ]]; then
+            echo "ERROR: version-minor is empty for ${{ matrix.version-label }}"
+            exit 1
+          fi
+          
+          echo "✅ Version branch name correct: $BRANCH_NAME"
+          echo "✅ Version parts: ${{ steps.koha-version.outputs.version-major }}.${{ steps.koha-version.outputs.version-minor }}"
+        fi
+        
+        echo "✅ All outputs verified successfully for ${{ matrix.version-label }}"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ The value can be one of `main`, `stable`, or `oldstable`.
 
 The current branch name that matches the given label.
 
-For example, if today is Dec 19, 2019, and I ask for 'stable', I will get back '19.11.x'.
-If I ask for 'oldstable' I will get '19.05.x'.
-If I do that same thing in 6 months ( the release cycle length ), I will get back '20.05.x' and '19.11.x' respectively.
+For example:
+- `main` → `main`
+- `stable` → `25.05.x` (current stable branch)
+- `oldstable` → `24.11.x` (previous stable branch)
+
+The actual version numbers change with each Koha release cycle (every 6 months).
 
 ### `branch-name`
 
@@ -25,22 +28,49 @@ Same as `current-branch-name`
 
 ### `version-major-minor`
 
-Major and minor version of Koha, e.g. `19.11`
+Major and minor version of Koha for versioned branches, e.g. `25.05`
+(Empty for `main` branch)
 
 ### `version-major`
 
-Major version of Koha, e.g. `19`
+Major version of Koha for versioned branches, e.g. `25`
+(Empty for `main` branch)
 
 ### `version-minor`
 
-Minor version of Koha, e.g. `11`
+Minor version of Koha for versioned branches, e.g. `05`
+(Empty for `main` branch)
 
 ## Example usage
 
 ```yaml
 - name: Get Koha Version Branch Name
   id: koha-version
-  uses: "bywatersolutions/github-action-koha-get-version-by-label@main"
+  uses: "bywatersolutions/github-action-koha-get-version-by-label@v2"
   with:
-    release-version: 'stable'
+    version-label: 'stable'
+
+- name: Use the branch name
+  run: |
+    echo "Koha stable branch is ${{ steps.koha-version.outputs.current-branch-name }}"
+    echo "Version is ${{ steps.koha-version.outputs.version-major-minor }}"
+    
+- name: Checkout Koha at stable version
+  uses: actions/checkout@v4
+  with:
+    repository: 'Koha-Community/Koha'
+    ref: ${{ steps.koha-version.outputs.current-branch-name }}
 ```
+
+## Changelog
+
+### v2.0.0
+- **BREAKING**: Requires GitHub Actions runner with `$GITHUB_OUTPUT` support
+- Fixed deprecated `::set-output` syntax, now uses modern `$GITHUB_OUTPUT`
+- Updated README example to use correct parameter name (`version-label` not `release-version`)
+- Improved examples with realistic Koha branch names and version numbers
+- Added comprehensive test workflow
+
+### v1.0.0
+- Initial release with support for `main`, `stable`, and `oldstable` labels
+- Multiple output formats for version information

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,8 +28,9 @@ echo "KOHA VERSION MAJOR MINOR: $KOHA_VERSION_MAJOR_MINOR"
 echo "KOHA VERSION MAJOR: $KOHA_VERSION_MAJOR"
 echo "KOHA VERSION MINOR: $KOHA_VERSION_MINOR"
 
-echo ::set-output name=current-branch-name::${KOHA_VERSION_BRANCH_NAME}
-echo ::set-output name=branch-name::${KOHA_VERSION_BRANCH_NAME}
-echo ::set-output name=version-major-minor::${KOHA_VERSION_MAJOR_MINOR}
-echo ::set-output name=version-major::${KOHA_VERSION_MAJOR}
-echo ::set-output name=version-minor::${KOHA_VERSION_MINOR}
+# Use modern GitHub Actions output syntax instead of deprecated ::set-output
+echo "current-branch-name=${KOHA_VERSION_BRANCH_NAME}" >> $GITHUB_OUTPUT
+echo "branch-name=${KOHA_VERSION_BRANCH_NAME}" >> $GITHUB_OUTPUT
+echo "version-major-minor=${KOHA_VERSION_MAJOR_MINOR}" >> $GITHUB_OUTPUT
+echo "version-major=${KOHA_VERSION_MAJOR}" >> $GITHUB_OUTPUT
+echo "version-minor=${KOHA_VERSION_MINOR}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I suggest we create a new v2 tag for this so it is opt-in.

Replace deprecated ::set-output commands with modern $GITHUB_OUTPUT syntax to eliminate deprecation warnings in GitHub Actions workflows.

Changes:
* Replace all 'echo ::set-output name=X::Y' with 'echo "X=Y" >> $GITHUB_OUTPUT'
* Update README with correct parameter name (version-label not release-version)
* Add changelog documenting breaking change for v2.0.0
* Improve README example with actual output usage

This addresses the GitHub Actions deprecation warning: 'The set-output command is deprecated and will be disabled soon'

The new syntax is supported in all current GitHub Actions runners and provides the same functionality without deprecation warnings.

Add test workflow to verify action functionality

Add comprehensive test workflow that:
* Tests all supported version labels (main, stable, oldstable)
* Verifies all output values are populated correctly
* Ensures the modern $GITHUB_OUTPUT syntax works properly
* Runs on push and pull request for quality assurance

This helps ensure the action works correctly after fixing the deprecated ::set-output syntax.